### PR TITLE
Updated TeX skeleton

### DIFF
--- a/LaTeX/Architectural Design Specifications.tex
+++ b/LaTeX/Architectural Design Specifications.tex
@@ -102,9 +102,6 @@
 			\subsubsection{Class Diagram}\label{subsec:uml-diagrams-events-class}
 			
 			
-			\subsubsection{Deployment Diagram}\label{subsec:uml-diagrams-events-dep}
-			
-			
 			\subsubsection{Activity Diagram}\label{subsec:uml-diagrams-events-act}
 			
 			
@@ -122,9 +119,6 @@
 		
 		
 			\subsubsection{Class Diagram}\label{subsec:uml-diagrams-notifications-class}
-			
-			
-			\subsubsection{Deployment Diagram}\label{subsec:uml-diagrams-notifications-dep}
 			
 			
 			\subsubsection{Activity Diagram}\label{subsec:uml-diagrams-notifications-act}
@@ -146,9 +140,6 @@
 			\subsubsection{Class Diagram}\label{subsec:uml-diagrams-poi-class}
 			
 			
-			\subsubsection{Deployment Diagram}\label{subsec:uml-diagrams-poi-dep}
-			
-			
 			\subsubsection{Activity Diagram}\label{subsec:uml-diagrams-poi-act}
 			
 			
@@ -168,9 +159,6 @@
 			\subsubsection{Class Diagram}\label{subsec:uml-diagrams-users-class}
 			
 			
-			\subsubsection{Deployment Diagram}\label{subsec:uml-diagrams-users-dep}
-			
-			
 			\subsubsection{Activity Diagram}\label{subsec:uml-diagrams-users-act}
 			
 			
@@ -182,7 +170,9 @@
 			
 			\subsubsection{Use Case Diagram}\label{subsec:uml-diagrams-users-uc}
 		
-		\clearpage
+	\clearpage
+	
+	\subsection{Deployment Diagram}\label{subsec:deployment-diagram}
 
 	\clearpage
 	


### PR DESCRIPTION
Removed the Deployment Diagram subsection from the subsystems and made
Deployment Diagram a section instead.